### PR TITLE
scripts: build third parties while cmake configuring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,11 @@ set(THIRDPARTY_DIR ${CMAKE_CURRENT_SOURCE_DIR}/build/third_parties)
 # Look in thirdparty prefix paths before anywhere else for system dependencies.
 set(CMAKE_PREFIX_PATH ${THIRDPARTY_DIR} ${CMAKE_PREFIX_PATH})
 
+execute_process(COMMAND ${CMAKE_SOURCE_DIR}/install_deps_if_necessary.sh RESULT_VARIABLE THIRDPARTY_SCRIPT_RESULT)
+if (NOT (${THIRDPARTY_SCRIPT_RESULT} EQUAL 0))
+    message(FATAL_ERROR "Thirdparty was built unsuccessfully, terminating.")
+endif ()
+
 ## Protobuf
 find_package(Protobuf REQUIRED)
 include_directories(SYSTEM ${PROTOBUF_INCLUDE_DIR})

--- a/deps_definition.sh
+++ b/deps_definition.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-BUILD_DIR=`pwd`/build
-TP_DIR="`pwd`/third_parties"
-TP_BUILD_DIR="$BUILD_DIR/third_parties"
-TP_STAMP_DIR="$TP_BUILD_DIR/stamp"
-PROTO_FILES_DIR=`pwd`/pb
+PROJECT_DIR=$(cd "$(dirname "$BASH_SOURCE")"; pwd)
+BUILD_DIR=$PROJECT_DIR/build
+TP_DIR=$PROJECT_DIR/third_parties
+TP_BUILD_DIR=$BUILD_DIR/third_parties
+TP_STAMP_DIR=$TP_BUILD_DIR/stamp
 
 PROTOBUF_VERSION=2.6.1
 PROTOBUF_NAME=protobuf-$PROTOBUF_VERSION
@@ -20,7 +20,7 @@ FMT_SOURCE=$TP_DIR/$FMT_NAME
 
 SILLY_VERSION=`git rev-parse @:silly | cut -c 1-7`
 SILLY_NAME=silly-$SILLY_VERSION
-SILLY_SOURCE=`pwd`/silly
+SILLY_SOURCE=$PROJECT_DIR/silly
 
 QINIU_CDN_URL_PREFIX=http://onnzg1pyx.bkt.clouddn.com
 

--- a/install_deps_if_necessary.sh
+++ b/install_deps_if_necessary.sh
@@ -2,9 +2,8 @@
 
 set -e
 
-TP_DIR=$(cd "$(dirname "$BASH_SOURCE")"; pwd)
-
-source ${TP_DIR}/deps_definition.sh
+PROJECT_DIR=$(cd "$(dirname "$BASH_SOURCE")"; pwd)
+source ${PROJECT_DIR}/deps_definition.sh
 
 echo "Installing necessary dependencies for building yaraft..."
 

--- a/install_deps_if_necessary.sh
+++ b/install_deps_if_necessary.sh
@@ -2,7 +2,9 @@
 
 set -e
 
-source deps_definition.sh
+TP_DIR=$(cd "$(dirname "$BASH_SOURCE")"; pwd)
+
+source ${TP_DIR}/deps_definition.sh
 
 echo "Installing necessary dependencies for building yaraft..."
 


### PR DESCRIPTION
After this PR, building yaraft will be simplified into a simple call:

```bash
mkdir cmake-build-debug
cmake ..
```
